### PR TITLE
Removing xy coordinates in regionprops call

### DIFF
--- a/WF_NTP/WF_NTP/WF_NTP_script.py
+++ b/WF_NTP/WF_NTP/WF_NTP_script.py
@@ -300,7 +300,7 @@ def process_frame(settings, Z, mean_brightness, nframes,
         if settings["do_full_prune"]:
             skel_labeled = prune_fully(skel_labeled)
 
-        skel_props = measure.regionprops(skel_labeled, coordinates='xy')
+        skel_props = measure.regionprops(skel_labeled)
         for j in range(len(skel_props)):
             prop_list[j]["length"] = skel_props[j].area
             prop_list[j]["eccentricity"] = skel_props[j].eccentricity


### PR DESCRIPTION
# Description

Fixing a bug regarding regionprops functions form scikit.
Solution removing deprecated parameter `coordinates='xy'`

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the needed labels
- [x] I have linked this PR to an issue
- [x] I have linked this PR to a milestone
- [x] I have linked this PR to a project
- [x] I have tested this code
- [ ] I have added / updated tests (unit / functionals / end-to-end / ...)
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs
